### PR TITLE
bind callback functions to options.context (if present)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,4 @@
 {
   "name": "jquery.ajax.fake",
-  "version": "0.5.1"
+  "version": "0.5.2"
 }

--- a/jquery.ajax.fake.js
+++ b/jquery.ajax.fake.js
@@ -45,10 +45,18 @@
     setTimeout(function() {
       var data = fakeWebServices[options.url](options.data);
       if(options.success) {
-        options.success( data );
+        if(options.context) {
+          $.proxy(options.success, options.context)( data );
+        } else {
+          options.success( data );
+        }
       }
       if(options.complete) {
-        options.complete( data );
+        if(options.context) {
+          $.proxy(options.complete, options.context)( data );
+        } else {
+          options.complete( data );
+        }
       }
       deferred.resolve( data );
       


### PR DESCRIPTION
I use $.ajax with context option like this:
```js
$.ajax({
	type:       "POST",
	fake:       true,
	url:        this.options.commissionRequestUrl,
	data:       commissionRequestData,
	context:    this,
	success:    this.onCommissionAjaxSuccess,
	error:      this.onCommissionAjaxError
});
```
and jquery.ajax.fake plugin should bind callbacks to given options.context