### PR TITLE
Add support for timeout fail, request method and response status + other

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,63 @@
-## jQuery.ajax.fake
-when you want to fake an ajax call, that's because your server's web service is just not ready yet, and whenever that web service is ready, switching back to it should cost nothing..
+# jQuery Ajax Fake
 
-with `jquery.ajax.fake` you simply write pure jQuery ajax call, with only one extra property `fake: true`
+Allow fake ajax calls to simulate it whenever you can't do it for real, on development environments.
 
-## How to use it
-include `jquery.ajax.fake.js` script into your markup, and create `webservices.fake.js` to handle fake ajax calls
+This library was customized and it's original source was created by *Anas Nakawa* and is available at http://anasnakawa.github.com/jquery.ajax.fake.
+
+## Files structure
+
+```bash
+/ (root)
+- dummy.js
+- jquery.ajax.fake.js
+- webservices.fake.js
+```
+
+## Getting started
+
+First include these files into your pages
+
 ```html
-<script src="jquery.ajax.fake.js"></script>
-<script src="webservices.fake.js"></script>
-```
-now lets say you want to fake a twitter timeline ajax call,  
-first simply create a fake web service in `webservices.fake.js` using the same url that you would use in your ajax call as a first parameter
-
-```js
-$.ajax.fake.registerWebservice('http://api.twitter.com/1/statuses/user_timeline.json?screen_name=anasnakawa', function(data) {
-    return [{
-        "text": "hey this is fake #tweet, retweet please :) #retweet"
-    }]
-});
+<body >
+  ...
+  <script type="text/javascript" src="path/to/jquery.js" defer ></script>
+  <script type="text/javascript" src="dummy.js" defer ></script>
+  <script type="text/javascript" src="jquery.ajax.fake.js" defer ></script>
+  <script type="text/javascript" src="webservices.fake.js" defer ></script>
+</body>
 ```
 
-now all you have to do is to add the property `fake: true` to your ajax call settings... and that's it!
-```js
-$.ajax({
-    type:'GET',
-    dataType:'jsonp',
-    fake: true,	// <<<---- that's it !
-    url:'http://api.twitter.com/1/statuses/user_timeline.json?screen_name=anasnakawa',
-    success:function(data, textStatus, XMLHttpRequest) {
-    	// your fake tweet should be here!
+Edit `webservices.fake.js` and define what should be the responses your webservices will return.
+
+
+```javascript
+fake.registerWebservice('some/path/here', function( data ) {
+  var response = {
+    "success": {
+      "propOne": "valueOne",
+      "propTwo": 5,
+      "...": "..."
+    },
+    "error": {
+      "status": 500,
+      "responseText": "{\"error\": \"server_error\", \"message\": \"This is the error message\"}"
     }
-});
+  };
+
+  return response;
+}, 'post', 'success');
 ```
 
-## Disabling fake ajax calls globally
-you can disable fake ajax calls globally by either remove both `jquery.ajax.fake.js` & `webservices.fake.js` script files from your markup, 
-or by just adding the following variable
-```js
-$.ajax.isFake = false;    // this will disable all fake ajax calls, and make the actual jQuery ajax handler work instead
+Then, to make things simple, you can define some key variables in dummy.js (or even inline, but not advised) which you can change whenever you need to test your calls for success or error.
+
+```javascript
+// defines the response status
+var dummyStatus = 'success';
+
+// defines whenever ajax will fake or not your calls
+var dummyAjax  = true;
+
+// pretends a delay on the response 
+var dummyDelay = 650; // 0.65 second;
+
 ```
-
-## What about promises ?
-don't worry, even fake ajax calls will work perfectly with `Deferred` objects that implements the `Promise` interface, as expected a fake ajax call will return a deferred object that will have a success & fail
-```js
-var deferred = $.ajax({
-    type:'GET',
-    dataType:'jsonp',
-    fake: true,       // <<<---- that's it !
-    url:'http://api.twitter.com/1/statuses/user_timeline.json?screen_name=anasnakawa'
-});
-
-deferred.done(function(data) {
-	// your fake tweet should be here!
-}).fail(function() {
-    // handle some errors
-});
-```
-
-## Installing via Bower
-```
-bower install jquery.ajax.fake
-```
-
-## Installing via Yeoman
-```
-yeoman install jquery.ajax.fake
-```
-
-## Reference
-```js
-fake    : false // is it fake ?
-wait	: 1000	// how long should wait before return ajax response
-```
-
-## Todo
-* failed requests
-
-## Credits
-created by Anas Nakawa [github](//github.com/anasnakawa), [twitter](//twitter.com/anasnakawa),  
-
-## License
-Released under the [MIT License](http://www.opensource.org/licenses/mit-license.php)

--- a/jquery.ajax.fake.js
+++ b/jquery.ajax.fake.js
@@ -5,30 +5,26 @@
  * author : Anas Nakawa anas.nakawa@gmail.com @anasnakawa
  * ------------------------------
  *
- * Custom version
- * author: Roger (rogerio.taques@gmail.com)
+ * Custom version for Rakuten
+ * @author: Roger (rogerio.taques@rakuten.com)
+ * @version 0.3
  */
 
 (function($){
 
-
+  // caching original jquery ajax method
   var
 
-    // caching original jquery ajax method
     ajax = $.ajax,
 
-    // defined the fake webservices
     fakeWebServices = {},
 
-    // complementary properties
     defaults = {
       fake  : false,  // is it fake ?
       wait  : 1000  // how long should wait before return ajax response
     },
 
-    // whenever complete callback is defined on ajax properties
-    // this method is called.
-    runComplete = function ( options, data ) {
+    _runComplete = function ( options, data ) {
 
       if(options.complete) {
         if(options.context) {
@@ -40,33 +36,29 @@
 
     },
 
-    // here goes the magic ...
     ajaxFake = function(options) {
-
-      // create a new deferred object for each request
+      // Create a new deferred object for each request
       var deferred = $.Deferred();
 
-      // if global setting is false
       // not fake, just return the original jquery ajax
       if ( $.ajax.isFake === false ) {
         return ajax.apply(this, arguments);
       }
 
-      // if not fake is defined by aja property
-      // not fake, just return the original jquery ajax
       if ( !options.fake ) {
         return ajax.apply(this, arguments);
       }
 
-      // if type isn't defined, assume it's get.
       if ( !options.type ) {
         options.type = 'get';
       } else {
         options.type = options.type.toLowerCase();
       }
 
-      // extend ajax options
       options = $.extend({}, defaults, options);
+
+      console.info('Ajax Fake: ', options.url);
+      console.log('Ajax Fake Data: ', options.data);
 
       // isn't webservices registered and request type valid?
       if( !fakeWebServices[options.url] || !fakeWebServices[options.url][options.type] ) {
@@ -107,7 +99,7 @@
           }
 
           // call complete callback from jquery
-          runComplete(options, data.type.error);
+          _runComplete(options, data.type.error);
           return deferred.reject('408');
 
         }, options.timeout);
@@ -130,12 +122,16 @@
         }
 
         // call complete callback from jquery
-        runComplete(options, data.type[data.status]);
+        _runComplete(options, data.type[data.status]);
 
         // return the promise object according to status
         switch (data.status) {
           case 'success':
             deferred.resolve( data.type.success );
+            break;
+
+          case 'error':
+            deferred.reject( data.type.error );
             break;
 
           default:
@@ -147,7 +143,6 @@
       return deferred.promise();
     },
 
-    // method to register fake webservices
     registerFakeWebService = function(url, callback, requestType, status) {
       if (!requestType) {
         requestType = 'get';
@@ -177,5 +172,7 @@
       registerWebservice  : registerFakeWebService,
       webServices         : fakeWebServices
     };
+
+  console.log('Fake ajax calls was initialised');
 
 })(jQuery);

--- a/jquery.ajax.fake.js
+++ b/jquery.ajax.fake.js
@@ -4,10 +4,6 @@
  * license: MIT (http://opensource.org/licenses/mit-license.php)
  * author : Anas Nakawa anas.nakawa@gmail.com @anasnakawa
  * ------------------------------
- *
- * Custom version for Rakuten
- * @author: Roger (rogerio.taques@rakuten.com)
- * @version 0.2
  */
 
 (function($){

--- a/jquery.ajax.fake.js
+++ b/jquery.ajax.fake.js
@@ -7,7 +7,7 @@
  *
  * Custom version for Rakuten
  * @author: Roger (rogerio.taques@rakuten.com)
- * @version 0.3
+ * @version 0.2
  */
 
 (function($){
@@ -173,6 +173,6 @@
       webServices         : fakeWebServices
     };
 
-  console.log('Fake ajax calls was initialised');
+  // console.log('Fake ajax calls was initialised');
 
 })(jQuery);

--- a/webservices.fake.js
+++ b/webservices.fake.js
@@ -1,20 +1,54 @@
-(function($) {
-  
+/*!------------------------------
+ * webservice.fake.js
+ * http://anasnakawa.github.com/jquery.ajax.fake
+ * license: MIT (http://opensource.org/licenses/mit-license.php)
+ * author : Anas Nakawa anas.nakawa@gmail.com @anasnakawa
+ * ------------------------------
+ */
+
+;(function($) {
+
   var fake = $.ajax.fake;
-  
-  fake.registerWebservice('http://www.twitter.com/userfeeds', function(data) {
-    return {
-      username: 'AnasNakawa'
-      , url:  'http://anasnakawa.wordpress.com'
+
+  // @use registerWebservice(path, callback [, method [, responseStatus]])
+  // @param {string} path             - Path to the webservice
+  // @param {function} callback       - A callback containing the return object with two states (success and error).
+  // @param {string} [method]         - Optional. Request method.
+  // @param {string} [responseStatus] - Optional. What response will be returned (success, error).
+
+
+  // using default request type (get) and response status (success)
+  fake.registerWebservice('some/path/here', function( data ) {
+    var response = {
+      "success": {
+        "propOne": "valueOne",
+        "propTwo": 5,
+        "...": "..."
+      },
+      "error": {
+        "status": 500,
+        "responseText": "{\"error\": \"server_error\", \"message\": \"This is the error messaage\"}"
+      }
     };
+
+    return response;
   });
-  
-  fake.registerWebservice('http://api.twitter.com/1/statuses/user_timeline.json?screen_name=anasnakawa&count=2', function(data) {
-    return [
-          {
-              "text": "hey this is fake #tweet, retweet please :) #retweet"
-          }
-      ]
-  });
-  
+
+  // force request type to 'post' and response status to what is set on dummy.js
+  fake.registerWebservice('some/path/here', function( data ) {
+    var response = {
+      "success": {
+        "propOne": "valueOne",
+        "propTwo": 5,
+        "...": "..."
+      },
+      "error": {
+        "status": 500,
+        "responseText": "{\"error\": \"server_error\", \"message\": \"This is the error messaage\"}"
+      }
+    };
+
+    return response;
+  }, 'post' /* http method */, 'success' /* response status */);
+
 })(jQuery);

--- a/webservices.fake.js
+++ b/webservices.fake.js
@@ -5,7 +5,6 @@
  * author : Anas Nakawa anas.nakawa@gmail.com @anasnakawa
  * ------------------------------
  */
-
 ;(function($) {
 
   var fake = $.ajax.fake;
@@ -49,6 +48,6 @@
     };
 
     return response;
-  }, 'post' /* http method */, 'success' /* response status */);
+  }, 'post', dummyStatus);
 
 })(jQuery);


### PR DESCRIPTION
- Whenever wait time is bigger than timeout set, return an error.
- If request method isn't available from webservices, returns an error.
- Possible to define different result status within one webservice.
- Possible to define different webservices with different methods for same URL.
- Adjusted the readme.md to better exemplify the use (you may wanna keep the original here)
- Added a couple of console logs to better show working results on browsers console.